### PR TITLE
Upload code coverage data only for pushes to main.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
     container: drgrice1/webwork3
     steps:
       - uses: actions/checkout@v2
-      - name: Build project and run tests
+      - name: Run unit tests
         env:
           HARNESS_PERL_SWITCHES: -MDevel::Cover
         run: |
@@ -27,8 +27,8 @@ jobs:
       #     name: coverage-report
       #     path: cover_db/
 
-      # FIXME: This results in a "400 Bad Request: Could not determine repo and owner", and so is disabled.
-      - name: push coverage analysis
+      - name: Push coverage analysis
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: cover -report codecov


### PR DESCRIPTION
Upload the code coverage data only when pushing to the main branch, and not for a pull request to the main branch.  Pull requests from a fork do not have access to the repository secrets needed for this.  This is really the only time we want this done anyway.

@eltenedor:  If you merge this pull request into your pull request, then things should work as desired.